### PR TITLE
prefer a hash for watch_files to allow easy addition of single files to the list

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,14 +31,15 @@ desired hostname comes from a dynamic source like EC2 meta-data.
 
 File monitoring is not really a part of papertrail but is included here:
 
-node[:papertrail][:watch_files] - This is a list of files that will be
-configured to be watched and included in the papertrail logging. This
-is useful for including output from applications that aren't
-configured to use syslog. Each entry in this list is a hash of:
+node[:papertrail][:watch_files] - This is a hash of files and associated tags
+that will be configured to be watched and included in the papertrail logging.
+This is useful for including output from applications that aren't configured
+to use syslog. Example:
 
-           [:filename] - Full path to the file.
-           [:tag] - What to tag log lines that come from this file. Best to
-                    use a short application name.
+    {
+      '/var/log/chef/client.log'    => 'chef',
+      '/var/log/something_else.log' => 'tag'
+    }
 
 = USAGE:
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,13 +22,41 @@ end
 syslogdir = "/etc/rsyslog.d"
 
 if node[:papertrail][:watch_files] && node[:papertrail][:watch_files].length > 0
+
+  watch_file_array = []
+
+  if node[:papertrail][:watch_files].respond_to?(:keys)
+
+    require 'digest/sha1'
+
+    node[:papertrail][:watch_files].each do |filename, tag|
+      watch_file_array << {
+        :filename => filename,
+        :tag      => tag,
+        :sha      => Digest::SHA1.hexdigest(filename)
+      }
+    end
+
+    # Sort to preserve order of the config
+    watch_file_array = watch_file_array.sort { |a,b| a[:filename] <=> b[:filename] }
+
+  elsif node[:papertrail][:watch_files].is_a?(Array)
+
+    # Deprecate but retain backwards compatibility
+    Chef::Log.info "DEPRECATION WARNING: Please convert this node's [:papertrail][:watch_files] attribute from an Array to a Hash"
+    Chef::Log.info "                     to allow use of override_attribtutes for addition of watch_files"
+
+    watch_file_array = node[:papertrail][:watch_files]
+
+  end
+
   template "#{syslogdir}/60-watch-files.conf" do
     source "watch-files.conf.erb"
     owner "root"
     group "root"
     mode "0644"
-    variables({:watch_files => node[:papertrail][:watch_files]})
-    notifies  :restart, resources(:service => syslogger)
+    variables(:watch_files => watch_file_array)
+    notifies :restart, resources(:service => syslogger)
   end
 end
 

--- a/templates/default/watch-files.conf.erb
+++ b/templates/default/watch-files.conf.erb
@@ -8,7 +8,7 @@ $ModLoad imfile
 # File 1
 $InputFileName <%= wf[:filename] %>
 $InputFileTag <%= wf[:tag] %>
-$InputFileStateFile state_file_<%= idx %>
+$InputFileStateFile state_file_<%= wf[:sha] || idx %>
 #$InputFileSeverity error
 #$InputFileFacility local7
 $InputRunFileMonitor


### PR DESCRIPTION
Allows a `base` role to have a few watch files, and then another role to add to that list by adding hash keys:

Base role:

```
"papertrail" => {
  "watch_files" => {
    "/var/log/chef/client.log" => "chef"
  }
}
```

A role that inherits from base:

```
"papertrail" => {
  "watch_files" => {
    "/var/log/thing_that_cant_log_to_syslog.log" => "thing"
  }
}
```
