### PR TITLE
Fixes for duplicated messages in papertrail

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "mike@librato.com"
 license          "Apache 2.0"
 description      "Installs/Configures Sys Logging to papertrailapp.com"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.3"
+version          "0.0.4"
 
 depends          "rsyslog"
 

--- a/templates/default/papertrail.conf.erb
+++ b/templates/default/papertrail.conf.erb
@@ -15,3 +15,5 @@ $ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
 *.*   @@<%= @host %>:<%= @port %>
 
 <%- end %>
+
+*.*   ~

--- a/templates/default/watch-files.conf.erb
+++ b/templates/default/watch-files.conf.erb
@@ -10,10 +10,7 @@ $ModLoad imfile
 #
 $InputFileName <%= wf[:filename] %>
 $InputFileTag <%= wf[:tag] %>
-$InputFileStateFile state_file_<%= wf[:sha] || idx %>
-#$InputFileSeverity error
-$InputFileFacility local7
+$InputFileStateFile papertrail_log_<%= wf[:sha] || idx %>
 $InputRunFileMonitor
-$InputFilePollInterval 10
 
 <%- end %>


### PR DESCRIPTION
I was seeing duplicated messages because they weren't being dropped correctly. The messages were also tagged under (I can't quite work out why) the wrong tags sometimes, too.
