### PR TITLE
set attributes from recipes in a chef 11-compatible way

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,7 +78,7 @@ hostname_name = node['papertrail']['hostname_name'].to_s
 hostname_cmd  = node['papertrail']['hostname_cmd'].to_s
 
 unless hostname_name.empty? && hostname_cmd.empty?
-  node['papertrail']['fixhostname'] = true
+  node.set['papertrail']['fixhostname'] = true
 
   if !hostname_name.empty?
     name = hostname_name


### PR DESCRIPTION
Fixes this warning:

```
WARN: Setting attributes without specifying a precedence is deprecated and will be
removed in Chef 11.0. To set attributes at normal precedence, change code like:
`node["key"] = "value"` # Not this
to:
`node.set["key"] = "value"` # This

Called from:
  cookbooks/papertrail/recipes/default.rb:81:in `from_file'
  gems_root/chef-10.20.0/lib/chef/mixin/from_file.rb:30:in `instance_eval'
  gems_root/chef-10.20.0/lib/chef/mixin/from_file.rb:30:in `from_file'
```

Also resolves https://github.com/librato/papertrail-cookbook/issues/5
