### PR TITLE
Add name attribute in metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,7 @@ license          "Apache 2.0"
 description      "Installs/Configures Sys Logging to papertrailapp.com"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.0.3"
+name             "papertrail"
 
 depends          "rsyslog"
 


### PR DESCRIPTION
In Ridley 3.0 ( used in berkshelf 3.0 ) it's mandatory to declare name attribute in cookbook's metadata.rb

The metadata at '/var/folders/mq/3fp1473d3g352rxgb3mksvg80000gp/T/d20140404-23692-o2xunn' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry. (Ridley::Errors::MissingNameAttribute)
