### PR TITLE
Support new log destinations on logs2.papertrailapp.com

### DIFF
--- a/attributes/papertrail.rb
+++ b/attributes/papertrail.rb
@@ -15,6 +15,11 @@ default['papertrail']['cert_file'] = "/etc/papertrail-bundle.pem"
 # URL to download certificate from.
 default['papertrail']['cert_url'] = "https://papertrailapp.com/tools/papertrail-bundle.pem"
 
+# What CN should we accept from remote host?
+# Note. Wildcard here is a hack to support logs2.papertrailapp.com's wildcard certificate
+# Rsyslog doesn't support Wildcard certificates, but a wildcard matches '*.papertrailapp.com'
+default['papertrail']['permitted_peer'] = "*.papertrailapp.com"
+
 # By default, this recipe will log to Papertrail using the system's
 # hostname. If you want to set the hostname that will be used (think
 # ephemeral cloud nodes) you can set one of the following. If either is

--- a/templates/default/papertrail.conf.erb
+++ b/templates/default/papertrail.conf.erb
@@ -5,6 +5,7 @@ $DefaultNetstreamDriverCAFile <%= @cert_file %> # trust these CAs
 $DefaultNetstreamDriver gtls # use gtls netstream driver
 $ActionSendStreamDriverMode 1 # require TLS
 $ActionSendStreamDriverAuthMode x509/name # authenticate by hostname
+$ActionSendStreamDriverPermittedPeer <%= node['papertrail']['permitted_peer'] %>
 $ActionResumeRetryCount <%= node['papertrail']['resume_retry_count'] %>
 $ActionResumeInterval 10
 $ActionQueueType LinkedList


### PR DESCRIPTION
When you add multiple destinations on papertrailapp you might end up on logs2.papertrailapp.com which tls-bits are configured a bit differently. This introduces support for logging to those destinations.
