### PR TITLE
Add queue size attribute.

### DIFF
--- a/attributes/papertrail.rb
+++ b/attributes/papertrail.rb
@@ -34,6 +34,9 @@ default['papertrail']['resume_retry_count'] = -1
 # The maximum disk space allowed for queues (default to 100M)
 default['papertrail']['queue_disk_space'] = '100M'
 
+# The maximum number of events to queue (default to 100000)
+default['papertrail']['queue_size'] = 100000
+
 # The name of the disk queue
 default['papertrail']['queue_file_name'] = '/var/log/rsyslog_queue_main'
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -23,6 +23,7 @@ describe 'papertrail-cookbook::default' do
     chef_run = runner.converge('papertrail-cookbook::default')
     expect(chef_run).to create_file_with_content '/etc/rsyslog.d/65-papertrail.conf', '$ActionResumeRetryCount -1'
     expect(chef_run).to create_file_with_content '/etc/rsyslog.d/65-papertrail.conf', '$ActionQueueMaxDiskSpace 100M'
+    expect(chef_run).to create_file_with_content '/etc/rsyslog.d/65-papertrail.conf', '$ActionQueueSize 100000'
     expect(chef_run).to create_file_with_content '/etc/rsyslog.d/65-papertrail.conf', '$ActionQueueFileName /var/log/rsyslog_queue_main'
   end
 end

--- a/templates/default/papertrail.conf.erb
+++ b/templates/default/papertrail.conf.erb
@@ -11,7 +11,7 @@ $ActionQueueType LinkedList
 $ActionQueueMaxDiskSpace <%= node['papertrail']['queue_disk_space'] %>
 $ActionQueueFileName <%= node['papertrail']['queue_file_name'] %>
 $ActionQueueSaveOnShutdown on
-$ActionQueueSize 100000
+$ActionQueueSize <%= node['papertrail']['queue_size'] %>
 $ActionQueueDiscardMark 97500
 $ActionQueueHighWaterMark 80000
 $ActionQueueCheckpointInterval 100


### PR DESCRIPTION
I was running into issues with high memory consumption when too many queued events existed.

This PR adds a queue_size attribute.
