### PR TITLE
set watch_files to an empty hash by default

### DIFF
--- a/attributes/papertrail.rb
+++ b/attributes/papertrail.rb
@@ -61,3 +61,4 @@ default['papertrail']['queue_file_name'] = 'papertrailqueue'
 #   node['papertrail']['watch_files'] =
 #              [{:filename => "/var/log/myapp.log", :tag => "myapp:"}]
 #
+default['papertrail']['watch_files'] = {}


### PR DESCRIPTION
This fixes a problem with chef attributes precedence handling.
Removing files from the watch_files hash is not actually being removed on host's attributes intermittently.
