### PR TITLE
Fix: Add priority to FixHostname template

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -59,7 +59,7 @@ describe 'papertrail::default' do
 
     it 'creates the fix host template' do
       expect(chef_run).to render_file(fixhost_configfile)
-        .with_content('FixHostname,"%timegenerated% some.host.tld %syslogtag%')
+        .with_content('FixHostname,"<%pri%>%timestamp% some.host.tld %syslogtag%')
     end
 
     it 'sets the fix host template in papertrail conf' do

--- a/templates/default/fixhostnames.conf.erb
+++ b/templates/default/fixhostnames.conf.erb
@@ -1,2 +1,3 @@
 # A template that renames our hostname
-$template FixHostname,"%timegenerated% <%= @name %> %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+# See http://www.rsyslog.com/doc/v8-stable/configuration/property_replacer.html for the msg replace templates
+$template FixHostname,"<%pri%> %timestamp% <%= @name %> %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"

--- a/templates/default/fixhostnames.conf.erb
+++ b/templates/default/fixhostnames.conf.erb
@@ -1,3 +1,3 @@
 # A template that renames our hostname
 # See http://www.rsyslog.com/doc/v8-stable/configuration/property_replacer.html for the msg replace templates
-$template FixHostname,"<%pri%> %timestamp% <%= @name %> %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$template FixHostname,"<%%pri%>%timestamp% <%= @name %> %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"


### PR DESCRIPTION
Fix: The FixHostname template currently does not transmit the log priority.

Note: There are several deprecation warnings in the specs, so I was unable to "just" add tests for this, and I considered changing the tests would blow this PR out of shape. PR for test setup is #22 - I rebased this PR on #22 to be able to test my changes, so preferably merge that one first